### PR TITLE
Adicionando o middleware de filtro na rota principal do framework

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -16,7 +16,6 @@ container.register({
 
 const vittaRouter = container.resolve('router');
 
-vittaRouter.use(PaginateHandler);
 vittaRouter.use(bodyParser.json());
 vittaRouter.use('/task', container.resolve('taskController').getRouter());
 

--- a/example/src/repository/task/TaskRepository.ts
+++ b/example/src/repository/task/TaskRepository.ts
@@ -8,8 +8,8 @@ export default class TaskRepository extends BaseRepositoryMysql<TaskDomain>
   implements ITaskRepository, IRepositoryGeneric<TaskDomain> {
   private _db;
   private _DbContext;
-  constructor({ DbContext, db }) {
-    super(Task, DbContext);
+  constructor({ DbContext, db, paginateParams }) {
+    super(Task, DbContext, paginateParams);
     this._db = db;
     this._DbContext = DbContext;
   }

--- a/framework/application/routes/index.ts
+++ b/framework/application/routes/index.ts
@@ -1,8 +1,12 @@
+import { PaginateHandler } from '../middlewares/paginateHandler';
+
 const { Router } = require('express');
 const bodyParser = require('body-parser');
 
 module.exports = () => {
   const router = Router();
+
+  router.use(PaginateHandler);
 
   const apiRouter = Router();
   apiRouter.use(bodyParser.json());
@@ -14,8 +18,6 @@ module.exports = () => {
   });
 
   router.use('/api', apiRouter);
-
-
 
   return router;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attiv",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Fast framework for software development using node",
   "main": "./lib/index.ts",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
 Foi adicionado o Middleware de filtro na rota principal, porque assim o usuário do framework não precisa habilitar o Middleware.