### PR TITLE
Implementando tratativa para colunas que são sensíveis e não devem ser usadas nas querys dinâmicas.

### DIFF
--- a/example/src/repository/database/models/subtasks.js
+++ b/example/src/repository/database/models/subtasks.js
@@ -3,7 +3,7 @@ module.exports = (sequelize, DataTypes) => {
     TaskId: DataTypes.INTEGER,
     title: {
       type: DataTypes.STRING,
-      hidden: true,
+      hidden: false,
     },
     description: DataTypes.STRING,
     ready: DataTypes.BOOLEAN,

--- a/example/src/repository/database/models/subtasks.js
+++ b/example/src/repository/database/models/subtasks.js
@@ -1,11 +1,20 @@
 module.exports = (sequelize, DataTypes) => {
-  const SubTasks = sequelize.define("SubTasks", {
+  const SubTasks = sequelize.define('SubTasks', {
     TaskId: DataTypes.INTEGER,
-    title: DataTypes.STRING,
+    title: {
+      type: DataTypes.STRING,
+      hidden: true,
+    },
     description: DataTypes.STRING,
     ready: DataTypes.BOOLEAN,
-    createdAt: DataTypes.DATE,
-    updatedAt: DataTypes.DATE,
+    createdAt: {
+      type: DataTypes.DATE,
+      hidden: true,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      hidden: true,
+    },
   });
 
   SubTasks.associate = function(models) {

--- a/example/src/repository/database/models/task.js
+++ b/example/src/repository/database/models/task.js
@@ -4,8 +4,14 @@ module.exports = (sequelize, DataTypes) => {
     description: DataTypes.STRING,
     email: DataTypes.STRING,
     ready: DataTypes.BOOLEAN,
-    createdAt: DataTypes.DATE,
-    updatedAt: DataTypes.DATE,
+    createdAt: {
+      type: DataTypes.DATE,
+      hidden: true,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      hidden: true,
+    },
   });
 
   Task.associate = function(models) {

--- a/framework/crosscutting/messages/message.ts
+++ b/framework/crosscutting/messages/message.ts
@@ -24,6 +24,7 @@ const messages = {
   },
   Filter: {
     VALUE_IS_NULL: 'FILTER QUERY IS NULL',
+    FIELD_HIDDEN: 'FIELD DISABLED FOR QUERY DYNAMIC',
   },
   RabbitMQ: {
     CONNECTION_FAILED: 'ERROR CONNECT RABBITMQ',

--- a/framework/infrastructure/database/mysql/BaseRepositoryMysql.ts
+++ b/framework/infrastructure/database/mysql/BaseRepositoryMysql.ts
@@ -145,6 +145,10 @@ export default abstract class BaseRepositoryMysql<T> implements IRepositoryGener
     amountSearchQueryIncludes.filterQ.forEach(query => {
       const [key, value] = query.split('=');
 
+      if (excludeAttributes.indexOf(key) >= 0) {
+        throw new APIError(`${key} - ${messages.Filter.FIELD_HIDDEN}`);
+      }
+
       if (!value.length) {
         throw new APIError(`${key} - ${messages.Filter.VALUE_IS_NULL}`);
       }
@@ -207,6 +211,7 @@ export default abstract class BaseRepositoryMysql<T> implements IRepositoryGener
         };
 
         const [entity, alias] = includeQuery.split('.');
+
         const model = this.DbContext.getModel(entity);
 
         if (alias !== undefined) {
@@ -234,6 +239,10 @@ export default abstract class BaseRepositoryMysql<T> implements IRepositoryGener
 
           const [key, value] = query.split('=');
           const [, relationValue] = key.split('.');
+
+          if (include['attributes'].exclude.indexOf(relationValue) >= 0) {
+            throw new APIError(`${key} - ${messages.Filter.FIELD_HIDDEN}`);
+          }
 
           if (!value.length) {
             throw new APIError(`${key} - ${messages.Filter.VALUE_IS_NULL}`);
@@ -271,8 +280,6 @@ export default abstract class BaseRepositoryMysql<T> implements IRepositoryGener
         queryIncludesList.push(include);
       });
     }
-
-    console.log(queryIncludesList);
 
     return { queryIncludesList, filterQ };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "attiv",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attiv",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Fast framework for software development using node",
   "main": "./lib/index.ts",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
# Descrição

Implementação genérica de configuração para tratar colunas que são sensíveis e não devem ser expostas para consulta.

***Observação:*** Todo o tratamento foi realizado somente para as consultas genéricas.

### Pré-condições

- Atualizar o framework para versão mais recente
- Adicionar no model do sequelize um novo atributo `hidden` da seguinte maneia
```
createdAt: {
  type: DataTypes.DATE,
  hidden: true,
},
updatedAt: {
  type: DataTypes.DATE,
  hidden: true,
 },

```


### Exemplo de uso básico com sucesso

Buscar a Task com createdAt e updatedAt habilitado como colunas sensíveis, ou seja, `hidden: true`

```
{
    "data": [
        {
            "id": 1,
            "title": "Fazer dever",
            "description": "lista com os deveres",
            "email": "elvis.souza@vitta.me",
            "ready": false
        }
    ]
}
```

### Exemplo de uso básico tentando consultar colunas que é sensível.

```
{
    "status": 500,
    "message": "createdAt - FIELD DISABLED FOR QUERY DYNAMIC",
    "detais": "Error: createdAt - FIELD DISABLED FOR QUERY DYNAMIC"
}
```