### PR TITLE
Fixing body parser middleware in router structure

### DIFF
--- a/framework/application/routes/index.ts
+++ b/framework/application/routes/index.ts
@@ -1,7 +1,6 @@
 import { PaginateHandler } from '../middlewares/paginateHandler';
 
 const { Router } = require('express');
-const bodyParser = require('body-parser');
 
 module.exports = () => {
   const router = Router();

--- a/framework/application/routes/index.ts
+++ b/framework/application/routes/index.ts
@@ -9,7 +9,6 @@ module.exports = () => {
   router.use(PaginateHandler);
 
   const apiRouter = Router();
-  apiRouter.use(bodyParser.json());
 
   apiRouter.use('/check', (req, res, next) => {
     return res

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "attiv",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attiv",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Fast framework for software development using node",
   "main": "./lib/index.ts",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## Description

I removed the use of the body-parser package in building the api's router. This package is already being imported at the root of the application (being a global middleware), and importing it again in the api, in addition to generating redundancy, does not allow me to configure the body size limit values in the client application.

## Other changes (e.g. bug fixes, UI tweaks, refactors)
Changed the package version for travis build.

## Related Tickets
--